### PR TITLE
GitHub workflows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,36 @@
+name: Format, Clippy and Build
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Ensures everything is formatted properly.
+      run: cargo fmt --all -- --check
+  clippy:
+    runs-on: ubuntu-latest
+    needs: fmt
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set of lints used by default to make code cleaner.
+      run: cargo clippy --all-targets --all-features -- -D clippy::all
+  build:
+    runs-on: ubuntu-latest
+    needs: clippy
+    steps:
+    - uses: actions/checkout@v2
+    - name: Ensures the code builds.
+      run: cargo build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,3 +34,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Ensures the code builds.
       run: cargo build
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      uses: actions/checkout@v2
+      name: Ensures all tests pass.
+      run: cargo test --all-targets --all-features

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+Cargo.lock
+.vscode


### PR DESCRIPTION
Adds a github workflow that does the following:
- Checks if code is formatted (using `cargo fmt`)
- Checks if `clippy` doesn't raise any warnings (and denies them_
- Checks if it can build correctly :)
- Tries running the tests (currently there are none so this is useless haha :p)
- Denies warnings from rustc (RUSTFLAGS="-D warnings")